### PR TITLE
Add codex review workflow

### DIFF
--- a/.github/workflows/codex-after-ci.yml
+++ b/.github/workflows/codex-after-ci.yml
@@ -1,0 +1,62 @@
+name: Codex review (after CI success)
+
+# Posts @codex review comment after successful CI on PRs.
+# Uses workflow_run to trigger after the main CI workflow completes.
+# File must live on the default branch to trigger (GitHub Actions limitation).
+#
+# REQUIRES: Repository secret 'CODEX_COMMENT_TOKEN' (PAT with):
+#   - Permissions: pull_requests: write (to post comments as a user)
+#   - Scopes: repo (private) or public_repo (public)
+# Without PAT, comments come from github-actions[bot] and Copilot may not respond.
+
+on:
+  workflow_run:
+    workflows: ["accparser CI"]  # Trigger after the main CI workflow
+    types: [completed]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  comment:
+    # Only run when CI succeeded and was triggered by a PR
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Debug workflow run info
+        run: |
+          echo "Workflow conclusion: ${{ github.event.workflow_run.conclusion }}"
+          echo "Workflow event: ${{ github.event.workflow_run.event }}"
+          echo "Workflow name: ${{ github.event.workflow_run.name }}"
+          echo "Pull requests: ${{ toJson(github.event.workflow_run.pull_requests) }}"
+
+      - name: Get PR number
+        id: pr
+        run: |
+          prs='${{ toJson(github.event.workflow_run.pull_requests) }}'
+          echo "PRs JSON: $prs"
+
+          if echo "$prs" | jq -e 'length == 0' >/dev/null || [ -z "$prs" ]; then
+            echo "No PR found for this workflow run"
+            echo "pr=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          pr_number=$(echo "$prs" | jq -r '.[0].number')
+          echo "Found PR number: $pr_number"
+          echo "pr=$pr_number" >> "$GITHUB_OUTPUT"
+
+      - name: Post @codex review comment
+        if: steps.pr.outputs.pr != ''
+        env:
+          GH_TOKEN: ${{ secrets.CODEX_COMMENT_TOKEN }}
+        run: |
+          echo "Posting @codex review comment to PR #${{ steps.pr.outputs.pr }}"
+          gh pr comment ${{ steps.pr.outputs.pr }} \
+            --repo ${{ github.repository }} \
+            --body "@codex review"
+          echo "✓ Posted @codex review comment"


### PR DESCRIPTION
## Summary
- add workflow_run-based job to comment "@codex review" after successful accparser CI runs on PRs
- require CODEX_COMMENT_TOKEN PAT to post as user; otherwise falls back to gh bot
- includes debug + PR-number extraction to avoid false triggers when no PR is attached

## Testing
- not run (workflow change only)
