### PR TITLE
[codex] Fix OpenACC IR ownership cleanup

### DIFF
--- a/src/OpenACCIR.cpp
+++ b/src/OpenACCIR.cpp
@@ -21,6 +21,11 @@ OpenACCDirective::~OpenACCDirective() {
   }
 }
 
+OpenACCEndDirective::~OpenACCEndDirective() {
+  delete paired_directive;
+  paired_directive = nullptr;
+}
+
 void OpenACCDataClause::addModifier(OpenACCDataClauseModifierKind modifier) {
   if (modifier == ACCC_DATA_MOD_unknown) {
     return;
@@ -1361,6 +1366,7 @@ void OpenACCReductionClause::mergeClause(OpenACCDirective *directive,
       mergeVarList(existing, incoming);
       current_clauses->pop_back();
       directive->getClausesInOriginalOrder()->pop_back();
+      delete incoming;
       break;
     }
   }

--- a/src/OpenACCIR.h
+++ b/src/OpenACCIR.h
@@ -327,7 +327,9 @@ protected:
   OpenACCDirective *paired_directive;
 
 public:
-  OpenACCEndDirective() : OpenACCDirective(ACCD_end) {};
+  OpenACCEndDirective()
+      : OpenACCDirective(ACCD_end), paired_directive(nullptr) {};
+  ~OpenACCEndDirective() override;
   void setPairedDirective(OpenACCDirective *_paired_directive) {
     paired_directive = _paired_directive;
   };


### PR DESCRIPTION
## Summary

This fixes two ownership cleanup holes in the OpenACC IR:

- add an `OpenACCEndDirective` destructor that deletes its paired directive
- delete the discarded incoming reduction clause when a reduction clause is merged into an existing clause

## Why

REX Memcheck coverage exposed these as real ownership gaps while exercising OpenACC parsing/AST cleanup through the embedded `accparser` submodule. The fix keeps ownership local to the IR nodes instead of relying on callers to patch cleanup later.

## Validation

```text
cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
cmake --build build -j80
ctest --test-dir build --output-on-failure -j80
```

Result: `918/918` tests passed.