### PR TITLE
[codex] upgrade CI workflows to Ubuntu 26.04

### DIFF
--- a/.github/workflows/accparser.yml
+++ b/.github/workflows/accparser.yml
@@ -16,8 +16,8 @@ jobs:
   build-llvm:
     strategy:
       matrix:
-        os: [ubuntu-24.04]
-        llvm: [17, 18, 19, 20, 21]
+        os: [ubuntu-26.04]
+        llvm: [21, 22]
 
     runs-on: ${{ matrix.os }}
     env:
@@ -25,18 +25,16 @@ jobs:
       CXX: /usr/bin/clang++-${{ matrix.llvm }}
 
     steps:
-    - uses: actions/checkout@v4
-    # NOTE: Ubuntu 24.04 ships antlr4 v4.9 but antlr4-cpp-runtime v4.10, which are API-incompatible; manually install the matching antlr4 v4.10.
+    - uses: actions/checkout@v7
+    # NOTE: Ubuntu 26.04 ships antlr4 v4.9 but antlr4-cpp-runtime v4.10, which are API-incompatible; manually install the matching antlr4 v4.10.
     - uses: StoneMoe/setup-antlr4@v4.10.1
 
-    - name: Add LLVM repository key
+    - name: Add LLVM repository
       run: |
-        wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/llvm-snapshot.asc > /dev/null
-
-    - name: Add LLVM repository on Ubuntu 24.04
-      if: ${{ matrix.os == 'ubuntu-24.04' }}
-      run: |
-        sudo add-apt-repository -y 'deb http://apt.llvm.org/noble/ llvm-toolchain-noble-${{ matrix.llvm }} main'
+        sudo apt-get update
+        sudo apt-get install -y ca-certificates gnupg wget
+        wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo gpg --dearmor --yes -o /usr/share/keyrings/llvm-snapshot.gpg
+        echo "deb [signed-by=/usr/share/keyrings/llvm-snapshot.gpg] http://apt.llvm.org/resolute/ llvm-toolchain-resolute-${{ matrix.llvm }} main" | sudo tee /etc/apt/sources.list.d/llvm-toolchain-resolute-${{ matrix.llvm }}.list
 
     - name: Install dependencies
       run: |
@@ -44,16 +42,16 @@ jobs:
         sudo apt-get install -y \
           libantlr4-runtime-dev \
           build-essential \
+          default-jre-headless \
           clang-${{ matrix.llvm }} \
           cmake
 
     - name: Build
       run: |
         cd $GITHUB_WORKSPACE/
-        mkdir build
-        cd build
-        cmake ${CMAKE_OPTIONS} -DCMAKE_CXX_FLAGS=${CXX_FLAGS} ..
-        make
+        cmake -E rm -rf build
+        cmake -S . -B build ${CMAKE_OPTIONS:-} -DCMAKE_CXX_FLAGS="${CXX_FLAGS:-}"
+        cmake --build build -- -j$(nproc)
 
     - name: Run built-in tests
       run: |
@@ -68,8 +66,8 @@ jobs:
   build-gnu:
     strategy:
       matrix:
-        os: [ubuntu-24.04]
-        gnu: [9, 10, 11, 12, 13, 14]
+        os: [ubuntu-26.04]
+        gnu: [13, 14, 15, 16]
 
     runs-on: ${{ matrix.os }}
     env:
@@ -77,26 +75,27 @@ jobs:
       CXX: /usr/bin/g++-${{ matrix.gnu }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
+    # NOTE: Ubuntu 26.04 ships antlr4 v4.9 but antlr4-cpp-runtime v4.10, which are API-incompatible; manually install the matching antlr4 v4.10.
     - uses: StoneMoe/setup-antlr4@v4.10.1
 
     - name: Install dependencies
       run: |
-        sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
         sudo apt-get update
         sudo apt-get install -y \
           libantlr4-runtime-dev \
           build-essential \
+          default-jre-headless \
           cmake \
+          gcc-${{ matrix.gnu }} \
           g++-${{ matrix.gnu }}
 
     - name: Build
       run: |
         cd $GITHUB_WORKSPACE/
-        mkdir build
-        cd build
-        cmake ${CMAKE_OPTIONS} -DCMAKE_CXX_FLAGS=${CXX_FLAGS} ..
-        make
+        cmake -E rm -rf build
+        cmake -S . -B build ${CMAKE_OPTIONS:-} -DCMAKE_CXX_FLAGS="${CXX_FLAGS:-}"
+        cmake --build build -- -j$(nproc)
 
     - name: Run built-in tests
       run: |

--- a/.github/workflows/codex-after-ci.yml
+++ b/.github/workflows/codex-after-ci.yml
@@ -25,7 +25,7 @@ jobs:
     if: >
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     steps:
       - name: Debug workflow run info
         run: |


### PR DESCRIPTION
## Summary

Upgrade the accparser CI workflows for Ubuntu 26.04 (`resolute`).

Changes include:

- Move workflow runners from `ubuntu-24.04` / `ubuntu-latest` to `ubuntu-26.04`.
- Update `actions/checkout` from `v4` to `v7`.
- Update the LLVM test matrix to the Ubuntu 26.04-supported LLVM versions: `21` and `22`.
- Switch the LLVM apt source from Ubuntu 24.04 `noble` to Ubuntu 26.04 `resolute` using a signed keyring source list.
- Update the GCC matrix to `13`, `14`, `15`, and `16`.
- Remove the old Ubuntu toolchain PPA dependency.
- Add explicit `default-jre-headless` installation so ANTLR generation is available in minimal local `act` images.
- Clean up the CMake build step to recreate `build/` deterministically and use `cmake --build`.

## Rationale

Ubuntu 26.04 only has usable LLVM coverage for LLVM 21 and 22 in the current package/repository setup. The previous LLVM 17-20 matrix entries no longer map to available `resolute` LLVM apt repositories.

For GCC, Ubuntu 26.04 provides GCC 11 through 16, but GCC 11 and 12 cannot link against Ubuntu 26.04's packaged `libantlr4-runtime.so`. That runtime requires `GLIBCXX_3.4.32` via `std::ios_base_library_init`, which GCC 11/12's libstdc++ do not provide. GCC 13 and newer provide the required symbol, so the CI matrix starts at GCC 13.

`StoneMoe/setup-antlr4@v4.10.1` is intentionally retained rather than bumped to a newer ANTLR action tag because Ubuntu 26.04 packages ANTLR C++ runtime 4.10. Generated code from ANTLR 4.13.x is API-incompatible with that runtime and fails to build.

## Validation

Validated locally with `act` using the Ubuntu 26.04 image:

- `act pull_request -W .github/workflows/accparser.yml -j build-llvm -P ubuntu-26.04=ompparser-act-ubuntu:26.04 --pull=false`
  - LLVM 21: built successfully; built-in tests passed; OpenACC VV `872/872` passed.
  - LLVM 22: built successfully; built-in tests passed; OpenACC VV `872/872` passed.
- `act pull_request -W .github/workflows/accparser.yml -j build-gnu -P ubuntu-26.04=ompparser-act-ubuntu:26.04 --pull=false`
  - GCC 13, 14, 15, and 16 completed successfully; OpenACC VV tests passed.
- `act --validate -W .github/workflows/accparser.yml`
- `act --validate -W .github/workflows/codex-after-ci.yml`
- `git diff --check`
- Stale-reference scan for old runners/repos/actions/review trigger strings returned no matches.